### PR TITLE
fix(orm): return true from setAttribute

### DIFF
--- a/app/orm-adapters/node-orm2.js
+++ b/app/orm-adapters/node-orm2.js
@@ -46,7 +46,7 @@ export default class NodeORM2Adapter extends ORMAdapter {
 
   setAttribute(model, property, value) {
     model.record[property] = value;
-    return value;
+    return true;
   }
 
   deleteAttribute(model, property) {


### PR DESCRIPTION
refs https://github.com/denali-js/denali/issues/299
- because the denali model class wraps the record in a Proxy object, we
need to return true from setAttribute, otherwise there will be an error
thrown if a user tries to set a falsey value